### PR TITLE
Prevent pushState on secondary mouse clicks

### DIFF
--- a/src/pushstate-anchor.js
+++ b/src/pushstate-anchor.js
@@ -6,8 +6,8 @@
   var HTMLPushStateAnchorElement = Object.create(HTMLAnchorElement.prototype);
 
   function pushStateAnchorEventListener(event) {
-    // open in new tab
-    if (event.ctrlKey || event.metaKey || event.which === 2) {
+    // open in new tab or open context menu (workaround for Firefox)
+    if (event.ctrlKey || event.metaKey || event.which === 2 || event.which === 3) {
       return;
     }
 


### PR DESCRIPTION
On Firefox (tested with 51.0.1 (64-bit), macOS Sierra 10.12.1), secondary clicks can fire `click` events in addition to `contextmenu` events (see http://stackoverflow.com/questions/30631415/both-contextmenu-click-events-fire-in-firefox-only-contextmenu-in-webkit).

This PR adds secondary mouse clicks to the list of ignored buttons in the `click` event callback.